### PR TITLE
fix: stabilize session and project workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **多模型、多项目、多文件、多任务、多工具，统一放进一个可控的桌面工作室。**
 
-[立即下载](https://github.com/ChaoYuZhang001/CaoGen/releases) | [快速开始](#3-分钟快速开始) | [贡献指南](./CONTRIBUTING.md) | [安全报告](./SECURITY.md) | [路线图](./ROADMAP.md) | [反馈问题](https://github.com/ChaoYuZhang001/CaoGen/issues)
+[官方网站](https://www.caogen.dev) | [立即下载](https://github.com/ChaoYuZhang001/CaoGen/releases) | [快速开始](#3-分钟快速开始) | [贡献指南](./CONTRIBUTING.md) | [安全报告](./SECURITY.md) | [路线图](./ROADMAP.md) | [反馈问题](https://github.com/ChaoYuZhang001/CaoGen/issues)
 
 </div>
 

--- a/scripts/page-operation-smoke.mjs
+++ b/scripts/page-operation-smoke.mjs
@@ -751,6 +751,81 @@ try {
   })
   await screenshot(cdp, '10-office')
 
+  await check(cdp, 'office new-session action opens an editable session workspace', async () => {
+    await clickSelector(cdp, '.office-actions .btn.btn-ghost')
+    await waitForSelector(cdp, '.welcome-composer-input', 10_000)
+    const state = await evalValue(
+      cdp,
+      `(() => {
+        const input = document.querySelector('.welcome-composer-input');
+        const project = document.querySelector('.welcome-project-select');
+        return {
+          welcome: Boolean(document.querySelector('.welcome')),
+          office: Boolean(document.querySelector('.office')),
+          editable: Boolean(input && !input.disabled && getComputedStyle(input).pointerEvents !== 'none'),
+          hasUnassigned: Boolean([...(project?.options ?? [])].find((option) => option.textContent?.includes('未关联项目')))
+        };
+      })()`
+    )
+    assert(state?.welcome === true && state?.office === false, `office new-session did not leave office: ${JSON.stringify(state)}`)
+    assert(state?.editable === true, `new-session composer should be editable: ${JSON.stringify(state)}`)
+    assert(state?.hasUnassigned === true, 'new sessions must allow the no-project collection')
+  })
+
+  await check(cdp, 'projects can be archived and restored from the sidebar', async () => {
+    await clickSelector(cdp, '.session-card.active')
+    await clickSelector(cdp, '[aria-label="项目操作: project"]')
+    await clickByText(cdp, '归档项目')
+    await waitForText(cdp, '已归档项目', 10_000)
+    const archived = JSON.parse(readFileSync(path.join(userDataDir, 'projects.json'), 'utf8'))
+    assert(archived.length === 1 && archived[0].archived === true, `project archive was not persisted: ${JSON.stringify(archived)}`)
+    await clickByText(cdp, '已归档项目')
+    await waitForSelector(cdp, '.sidebar-archived-projects-section [aria-label="项目操作: project"]')
+    await screenshot(cdp, '10a-project-archived')
+    await clickSelector(cdp, '.sidebar-archived-projects-section [aria-label="项目操作: project"]')
+    await clickByText(cdp, '恢复项目')
+    await waitForSelector(cdp, '.sidebar-projects-section [aria-label="项目操作: project"]')
+    const restored = JSON.parse(readFileSync(path.join(userDataDir, 'projects.json'), 'utf8'))
+    assert(restored.length === 1 && restored[0].archived !== true, `project restore was not persisted: ${JSON.stringify(restored)}`)
+  })
+
+  await check(cdp, 'deleting the last session leaves a usable new-session composer', async () => {
+    await evalValue(cdp, `(() => { window.confirm = () => true; return true })()`)
+    await clickSelector(cdp, '.session-card.active .session-card-more')
+    await clickByText(cdp, '关闭会话')
+    await waitForSelector(cdp, '.welcome-composer-input', 10_000)
+    await waitForNoSelector(cdp, '.modal-backdrop', 10_000)
+    await waitForSelector(cdp, '.history-card .session-card-more', 10_000)
+    await clickSelector(cdp, '.history-card .session-card-more')
+    await clickByText(cdp, '删除')
+    await waitForNoSelector(cdp, '.history-card', 10_000)
+    await focusWelcomeComposer(cdp)
+    await typeText(cdp, '删除后仍可输入')
+    const inputValue = await evalValue(cdp, `document.querySelector('.welcome-composer-input')?.value || ''`)
+    assert(inputValue === '删除后仍可输入', `new-session composer rejected input after delete: ${JSON.stringify(inputValue)}`)
+  })
+
+  await check(cdp, 'projects can be deleted without deleting their directories', async () => {
+    await clickSelector(cdp, '[aria-label="项目操作: project"]')
+    await clickByText(cdp, '删除项目')
+    await waitForNoAriaLabel(cdp, '项目操作: project', 10_000)
+    const savedProjects = JSON.parse(readFileSync(path.join(userDataDir, 'projects.json'), 'utf8'))
+    assert(savedProjects.length === 0, `project delete was not persisted: ${JSON.stringify(savedProjects)}`)
+    assert(existsSync(projectDir), 'deleting a project must not delete its directory')
+    await waitForText(cdp, '未关联项目', 10_000)
+  })
+  await screenshot(cdp, '11-session-project-lifecycle')
+
+  await check(cdp, 'a new session can be created without selecting a project', async () => {
+    await setInputByPlaceholder(cdp, '/path/to/project', projectDir)
+    await clickSelector(cdp, '.welcome-send')
+    await waitForSelector(cdp, '.workbench', 10_000)
+    await waitForSelector(cdp, '.sidebar-unassigned-group .session-card.active', 10_000)
+    const savedProjects = JSON.parse(readFileSync(path.join(userDataDir, 'projects.json'), 'utf8'))
+    assert(savedProjects.length === 0, `an unassigned session must not recreate a project: ${JSON.stringify(savedProjects)}`)
+  })
+  await screenshot(cdp, '12-unassigned-session')
+
   await cdp.close()
 } finally {
   const exited = await terminate(app)
@@ -1632,6 +1707,19 @@ async function focusComposer(cdp) {
   assert(ok === true, 'composer input not found')
 }
 
+async function focusWelcomeComposer(cdp) {
+  const ok = await evalValue(
+    cdp,
+    `(() => {
+      const el = document.querySelector('.welcome-composer-input');
+      if (!el) return false;
+      el.focus();
+      return document.activeElement === el;
+    })()`
+  )
+  assert(ok === true, 'new-session composer input not found or not focusable')
+}
+
 async function typeText(cdp, text) {
   for (const char of text) {
     await cdp.send('Input.dispatchKeyEvent', { type: 'char', text: char })
@@ -1680,6 +1768,26 @@ async function waitForNoAriaLabel(cdp, label, timeout = 5000) {
     await sleep(150)
   }
   throw new Error(`aria-label still found: ${label}`)
+}
+
+async function waitForSelector(cdp, selector, timeout = 5000) {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    const found = await evalValue(cdp, `!!document.querySelector(${JSON.stringify(selector)})`)
+    if (found) return
+    await sleep(150)
+  }
+  throw new Error(`selector not found: ${selector}`)
+}
+
+async function waitForNoSelector(cdp, selector, timeout = 5000) {
+  const start = Date.now()
+  while (Date.now() - start < timeout) {
+    const found = await evalValue(cdp, `!!document.querySelector(${JSON.stringify(selector)})`)
+    if (!found) return
+    await sleep(150)
+  }
+  throw new Error(`selector still found: ${selector}`)
 }
 
 async function waitForCanvasPixels(cdp, timeout = 10_000) {

--- a/scripts/start-suggestions-e2e.mjs
+++ b/scripts/start-suggestions-e2e.mjs
@@ -97,7 +97,7 @@ try {
   await page.waitForSelector('.app', { timeout: 20_000 })
   await waitForAgentDesk(page)
 
-  await check('seed session, memory failure, and failed routine through preload IPC', async () => {
+  await check('seed session, scoped memory, and routines through preload IPC', async () => {
     session = await page.evaluate((cwd) => {
       return window.agentDesk.createSession({
         cwd,
@@ -120,6 +120,17 @@ try {
         reason: 'failure smoke'
       })
       const memory = await window.agentDesk.acceptMemoryDraft(sessionId, draft.id)
+      const unrelatedRoutine = await window.agentDesk.createRoutine({
+        id: 'routine-unrelated-failed',
+        name: 'Unrelated failed routine marker',
+        prompt: 'failed unrelated routine marker must stay out of this project',
+        projectCwd: `${cwd}-unrelated`,
+        schedule: '@daily',
+        enabled: true,
+        providerId: 'unrelated-provider',
+        model: 'unrelated-model',
+        engine: 'openai'
+      })
       const routine = await window.agentDesk.createRoutine({
         id: 'routine-a4-failed',
         name: 'Failed nightly routine',
@@ -131,10 +142,11 @@ try {
         model: 'mock-responses',
         engine: 'openai'
       })
-      return { memory, routine }
+      return { memory, routine, unrelatedRoutine }
     }, session.id, projectDir)
     assert(seeded.memory?.id, 'accepted memory entry missing')
     assert(seeded.routine?.id === 'routine-a4-failed', 'routine seed mismatch')
+    assert(seeded.unrelatedRoutine?.id === 'routine-unrelated-failed', 'unrelated routine seed mismatch')
   })
 
   await page.reload({ waitUntil: 'domcontentloaded' })
@@ -142,7 +154,19 @@ try {
   await waitForAgentDesk(page)
   await page.waitForFunction(() => document.body.innerText.includes('A4 start suggestions'), { timeout: 15_000 })
 
-  await check('session activation renders start suggestions panel', async () => {
+  await check('session activation does not render start suggestions by default', async () => {
+    await sleep(750)
+    const rendered = await readRenderedSuggestions(page)
+    assert(rendered.panel === false, `start suggestions opened automatically: ${JSON.stringify(rendered)}`)
+    assert(rendered.status === '', `start suggestions started loading automatically: ${JSON.stringify(rendered)}`)
+    report.renderedBeforeOpen = rendered
+  })
+  await screenshot(page, '01-session-default-no-suggestions')
+
+  await check('manual menu action loads and renders scoped start suggestions', async () => {
+    await page.click('.header-more > button')
+    await page.waitForSelector('[data-header-action="start-suggestions"]', { visible: true, timeout: 5_000 })
+    await page.click('[data-header-action="start-suggestions"]')
     const rendered = await waitForValue(
       () => readRenderedSuggestions(page),
       (value) => value.panel && value.visible > 0 && value.items.length > 0,
@@ -156,7 +180,7 @@ try {
     )
     report.renderedInitial = rendered
   })
-  await screenshot(page, '01-start-suggestions-panel')
+  await screenshot(page, '02-start-suggestions-panel')
 
   await check('start suggestion IPC maps memory, routine, history, worktree, git, and package sources', async () => {
     const result = await page.evaluate(async (sessionId) => {
@@ -173,12 +197,24 @@ try {
     assert(result.durationMs < 3000, `startSuggestions:get took too long: ${result.durationMs}ms`)
     assertHasSuggestion(suggestions, 'memory-failure', 'memory')
     assertHasSuggestion(suggestions, 'routine-failure', 'routine')
+    assertHasSuggestion(suggestions, 'recent-failure', 'recent-failure')
     assertHasSuggestion(suggestions, 'history-continue', 'history')
     assertHasSuggestion(suggestions, 'worktree-review', 'worktree')
     assertHasSuggestion(suggestions, 'git-dirty', 'git-status')
     assert(
       suggestions.some((item) => item.id === 'package-verify' && item.source === 'package-json'),
       `missing package-json verification suggestion: ${describeSuggestions(suggestions)}`
+    )
+    const scopedSignals = ['recent-failure', 'routine-failure', 'history-continue']
+      .map((suggestionId) => suggestions.find((item) => item.id === suggestionId)?.body || '')
+      .join('\n')
+    assert(
+      !/unrelated (provider|routine|history)/i.test(scopedSignals),
+      `unrelated project/provider signals leaked into suggestions: ${scopedSignals}`
+    )
+    assert(
+      scopedSignals.includes('current provider failure marker'),
+      `current provider failure was not retained: ${scopedSignals}`
     )
   })
 
@@ -232,7 +268,7 @@ try {
     report.userMessages = transcript
     report.renderedAfterSend = after
   })
-  await screenshot(page, '02-start-suggestion-sent')
+  await screenshot(page, '03-start-suggestion-sent')
 } catch (error) {
   report.error = error instanceof Error ? error.stack || error.message : String(error)
   if (!report.checks.some((item) => item.status === 'fail')) {
@@ -288,11 +324,13 @@ async function readRenderedSuggestions(page) {
       title: item.querySelector('.start-suggestions-item-title')?.textContent?.trim() || ''
     }))
     const sendButton = document.querySelector('[data-start-suggestion-action="send"]')
+    const status = document.querySelector('[data-start-suggestions-status]')
     return {
       panel: Boolean(panel),
       visible: Number(panel?.getAttribute('data-start-suggestions-visible') || 0),
       total: Number(panel?.getAttribute('data-start-suggestions-total') || 0),
       items,
+      status: status?.getAttribute('data-start-suggestions-status') || '',
       sendButtonDisabled: sendButton ? sendButton.disabled === true : true,
       bodyText: document.body.innerText.slice(0, 800)
     }
@@ -333,7 +371,6 @@ function prepareProject() {
     '# A4 start suggestions\n\nTODO: failed validation branch must be repaired.\n',
     'utf8'
   )
-  writeFileSync(path.join(projectDir, 'TODO.md'), 'FIXME: cover git dirty state in rendered start suggestions.\n', 'utf8')
 }
 
 function writeSeedHistory() {
@@ -341,6 +378,18 @@ function writeSeedHistory() {
     path.join(userDataDir, 'sessions.json'),
     JSON.stringify(
       [
+        {
+          id: 'hist-unrelated-start-suggestions',
+          title: 'Continue unrelated history marker',
+          cwd: `${projectDir}-unrelated`,
+          model: 'unrelated-model',
+          providerId: 'unrelated-provider',
+          permissionMode: 'default',
+          sdkSessionId: 'hist-sdk-unrelated-start-suggestions',
+          createdAt: Date.now() - 40_000,
+          updatedAt: Date.now() - 20_000,
+          costUsd: 0
+        },
         {
           id: 'hist-a4-start-suggestions',
           title: 'Continue unfinished validation branch',
@@ -442,6 +491,38 @@ function writeMockUserData(port) {
         disallowedTools: '',
         autoSkillLearningEnabled: false,
         office: { showBadges: true, liveliness: 1, catEars: false }
+      },
+      null,
+      2
+    )
+  )
+  writeFileSync(
+    path.join(userDataDir, 'provider-health.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        providers: {
+          'unrelated-provider': {
+            providerId: 'unrelated-provider',
+            failures: 1,
+            consecutiveFailures: 1,
+            lastError: 'unrelated provider failure marker',
+            lastFailureAt: Date.now() - 1_000,
+            lastUsedAt: Date.now() - 1_000,
+            recentFailures: [],
+            healthy: true
+          },
+          'mock-openai': {
+            providerId: 'mock-openai',
+            failures: 1,
+            consecutiveFailures: 1,
+            lastError: 'current provider failure marker',
+            lastFailureAt: Date.now() - 2_000,
+            lastUsedAt: Date.now() - 2_000,
+            recentFailures: [],
+            healthy: true
+          }
+        }
       },
       null,
       2

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1008,17 +1008,25 @@ export function registerIpc(): void {
     const session = sessionManager.get(id)
     if (!session) return []
     const projectRoot = session.meta.sourceCwd ?? session.meta.cwd
+    const resolvedProjectRoot = resolve(projectRoot)
+    const belongsToCurrentProject = (cwd: unknown): cwd is string =>
+      typeof cwd === 'string' && cwd.trim().length > 0 && resolve(cwd) === resolvedProjectRoot
     const memory = await readProjectMemory(projectRoot, memoryRoot()).catch(() => ({ entries: [] }))
     const worktree = getManagedWorktreeSummary(id)
-    const historySignals: StartSuggestionSignal[] = listHistory().slice(0, 8).map((entry) => ({
-      id: entry.id,
-      title: entry.title,
-      body: entry.cwd,
-      source: 'history',
-      updatedAt: entry.updatedAt,
-      ok: true
-    }))
-    const routines = await listRoutines(routineStoreRoot())
+    const historySignals: StartSuggestionSignal[] = listHistory()
+      .filter((entry) => belongsToCurrentProject(entry.sourceCwd ?? entry.cwd))
+      .slice(0, 8)
+      .map((entry) => ({
+        id: entry.id,
+        title: entry.title,
+        body: entry.sourceCwd ?? entry.cwd,
+        source: 'history',
+        updatedAt: entry.updatedAt,
+        ok: true
+      }))
+    const routines = (await listRoutines(routineStoreRoot())).filter((routine) =>
+      belongsToCurrentProject(routine.projectCwd)
+    )
     const routineSignals: StartSuggestionSignal[] = routines.map((routine) => ({
       id: routine.id,
       title: routine.name,
@@ -1044,7 +1052,9 @@ export function registerIpc(): void {
       }))
     // recentFailures:用 Provider 健康度作为唯一可靠的失败来源。
     // 成功恢复会清掉 lastError,历史失败仍保留在 recentFailures 供控制中心审计。
+    const activeProviderId = session.meta.providerId || 'local-login'
     const recentFailureSignals: StartSuggestionSignal[] = listHealth()
+      .filter((health) => health.providerId === activeProviderId)
       .filter((h) => !h.healthy || (typeof h.lastError === 'string' && h.lastError.trim() !== ''))
       .map((h) => {
         const latest = h.recentFailures[0]
@@ -1099,9 +1109,13 @@ export function registerIpc(): void {
   })
 
   ipcMain.handle('projects:list', () => listProjects())
-  ipcMain.handle('projects:update', (_e, id: string, patch: { name?: string }) =>
-    updateProject(id, patch ?? {})
-  )
+  ipcMain.handle('projects:update', (_e, id: string, patch: { name?: string; archived?: boolean }) => {
+    if (typeof id !== 'string' || id.length === 0) throw new Error('必须指定项目')
+    return updateProject(id, {
+      ...(typeof patch?.name === 'string' ? { name: patch.name } : {}),
+      ...(typeof patch?.archived === 'boolean' ? { archived: patch.archived } : {})
+    })
+  })
   ipcMain.handle('projects:delete', (_e, id: string) => {
     deleteProject(id)
   })

--- a/src/main/projects.ts
+++ b/src/main/projects.ts
@@ -2,7 +2,7 @@ import { app } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import type { Project } from '../shared/types'
+import type { Project, ProjectUpdate } from '../shared/types'
 
 const MAX_PROJECTS = 50
 
@@ -47,6 +47,7 @@ export function touchProject(path: string): Project {
   const existing = list.find((p) => p.path === path)
   if (existing) {
     existing.lastUsedAt = Date.now()
+    existing.archived = false
     persist()
     return existing
   } else {
@@ -62,11 +63,12 @@ export function getProject(id: string): Project | undefined {
   return load().find((project) => project.id === id)
 }
 
-export function updateProject(id: string, patch: { name?: string }): Project | null {
+export function updateProject(id: string, patch: ProjectUpdate): Project | null {
   const list = load()
   const proj = list.find((p) => p.id === id)
   if (!proj) return null
   if (patch.name !== undefined) proj.name = patch.name.trim() || baseName(proj.path)
+  if (patch.archived !== undefined) proj.archived = patch.archived
   persist()
   return proj
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,7 @@ import type {
   PermissionModeId,
   PreviewAnnotationInput,
   PluginRegistryScanOptions,
+  ProjectUpdate,
   ProjectMemoryDraftInput,
   ProviderModelFetchInput,
   ProviderInput,
@@ -226,7 +227,7 @@ const api: AgentDeskApi = {
   importMigrationAssets: (cwd: string, paths: string[]) =>
     ipcRenderer.invoke('migration:import', cwd, paths),
   listProjects: () => ipcRenderer.invoke('projects:list'),
-  updateProject: (id: string, patch: { name?: string }) =>
+  updateProject: (id: string, patch: ProjectUpdate) =>
     ipcRenderer.invoke('projects:update', id, patch),
   deleteProject: (id: string) => ipcRenderer.invoke('projects:delete', id),
   readProjectContext: (projectPath: string) =>

--- a/src/renderer/src/components/ChatHeaderIcons.tsx
+++ b/src/renderer/src/components/ChatHeaderIcons.tsx
@@ -10,6 +10,7 @@ export type HeaderIconName =
   | 'files'
   | 'plugins'
   | 'routines'
+  | 'suggestions'
   | 'memory'
   | 'browser'
   | 'terminal'
@@ -81,6 +82,13 @@ const PATHS: Record<HeaderIconName, React.JSX.Element> = {
     <>
       <circle cx="8" cy="8" r="5.2" />
       <path d="M8 5v3l2 1.4" />
+    </>
+  ),
+  // 灯泡 / 开工建议
+  suggestions: (
+    <>
+      <path d="M5.4 10.4h5.2M6.1 12.7h3.8" />
+      <path d="M5.2 8.9A4.1 4.1 0 1 1 10.8 8.9c-.8.6-1.1 1-1.2 1.5H6.4c-.1-.5-.4-.9-1.2-1.5Z" />
     </>
   ),
   // 书签 / 记忆

--- a/src/renderer/src/components/ChatView.tsx
+++ b/src/renderer/src/components/ChatView.tsx
@@ -66,7 +66,9 @@ export default function ChatView(): React.JSX.Element | null {
   const scrollFrame = useRef<number | null>(null)
   const [scrollSnapshot, setScrollSnapshot] = useState<ScrollSnapshot>({ top: 0, height: 0 })
   const [moreOpen, setMoreOpen] = useState(false)
+  const [startSuggestionsSessionId, setStartSuggestionsSessionId] = useState<string | null>(null)
   const moreRef = useRef<HTMLDivElement>(null)
+  const startSuggestionsOpen = startSuggestionsSessionId === activeId
 
   const updateScrollSnapshot = useCallback((): void => {
     const el = scrollRef.current
@@ -144,8 +146,9 @@ export default function ChatView(): React.JSX.Element | null {
   }, [activeId, updateScrollSnapshot])
 
   useEffect(() => {
-    if (activeId) void refreshStartSuggestions()
-  }, [activeId, refreshStartSuggestions])
+    setMoreOpen(false)
+    setStartSuggestionsSessionId(null)
+  }, [activeId])
 
   useEffect(() => {
     let lastEsc = 0
@@ -301,6 +304,7 @@ export default function ChatView(): React.JSX.Element | null {
             {moreOpen && (
               <div className="header-more-menu" role="menu">
                 <MenuItem
+                  action="subagents"
                   icon="subagents"
                   label={t('subagentsShort')}
                   onSelect={() => {
@@ -309,6 +313,7 @@ export default function ChatView(): React.JSX.Element | null {
                   }}
                 />
                 <MenuItem
+                  action="plugins"
                   icon="plugins"
                   label={t('pluginsShort')}
                   onSelect={() => {
@@ -317,6 +322,7 @@ export default function ChatView(): React.JSX.Element | null {
                   }}
                 />
                 <MenuItem
+                  action="routines"
                   icon="routines"
                   label={t('routinesShort')}
                   onSelect={() => {
@@ -325,6 +331,21 @@ export default function ChatView(): React.JSX.Element | null {
                   }}
                 />
                 <MenuItem
+                  action="start-suggestions"
+                  icon="suggestions"
+                  label={t('startSuggestionsShort')}
+                  onSelect={() => {
+                    setMoreOpen(false)
+                    if (startSuggestionsOpen) {
+                      setStartSuggestionsSessionId(null)
+                      return
+                    }
+                    setStartSuggestionsSessionId(activeId)
+                    void refreshStartSuggestions()
+                  }}
+                />
+                <MenuItem
+                  action="memory"
                   icon="memory"
                   label={t('memoryShort')}
                   onSelect={() => {
@@ -349,18 +370,33 @@ export default function ChatView(): React.JSX.Element | null {
 
       <div className="chat-scroll" ref={scrollRef} onScroll={onScroll}>
         <div className="chat-inner">
-          {startSuggestionsError && (
+          {startSuggestionsOpen && startSuggestionsLoading && (
+            <div className="notice start-suggestions-chat-notice" data-start-suggestions-status="loading">
+              {t('startSuggestionsLoading')}
+            </div>
+          )}
+          {startSuggestionsOpen && startSuggestionsError && (
             <div className="notice notice-error start-suggestions-chat-notice">{startSuggestionsError}</div>
           )}
-          <StartSuggestionsPanel
-            suggestions={startSuggestions}
-            compact
-            disabled={running || startSuggestionsLoading}
-            maxVisible={3}
-            onSendToAgent={(suggestion) => void sendStartSuggestion(suggestion)}
-            onLater={(suggestion) => laterStartSuggestion(suggestion.id)}
-            onIgnore={(suggestion) => ignoreStartSuggestion(suggestion.id)}
-          />
+          {startSuggestionsOpen &&
+            !startSuggestionsLoading &&
+            !startSuggestionsError &&
+            startSuggestions.length === 0 && (
+              <div className="notice start-suggestions-chat-notice" data-start-suggestions-status="empty">
+                {t('startSuggestionsEmpty')}
+              </div>
+            )}
+          {startSuggestionsOpen && (
+            <StartSuggestionsPanel
+              suggestions={startSuggestions}
+              compact
+              disabled={running || startSuggestionsLoading}
+              maxVisible={3}
+              onSendToAgent={(suggestion) => void sendStartSuggestion(suggestion)}
+              onLater={(suggestion) => laterStartSuggestion(suggestion.id)}
+              onIgnore={(suggestion) => ignoreStartSuggestion(suggestion.id)}
+            />
+          )}
           <MessageList
             activeId={activeId}
             items={session.items}
@@ -688,14 +724,21 @@ function IconButton({ icon, label, onClick }: IconButtonProps): React.JSX.Elemen
 }
 
 interface MenuItemProps {
+  action: string
   icon: HeaderIconName
   label: string
   onSelect: () => void
 }
 
-function MenuItem({ icon, label, onSelect }: MenuItemProps): React.JSX.Element {
+function MenuItem({ action, icon, label, onSelect }: MenuItemProps): React.JSX.Element {
   return (
-    <button type="button" className="header-more-item" role="menuitem" onClick={onSelect}>
+    <button
+      type="button"
+      className="header-more-item"
+      role="menuitem"
+      data-header-action={action}
+      onClick={onSelect}
+    >
       <HeaderIcon name={icon} />
       <span>{label}</span>
     </button>

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import { APP_ICON_URL, APP_NAME } from '../brand'
 import type {
   HistoryEntry,
   LayoutSettings,
+  Project,
   SessionMeta,
   SessionStatus,
   TaskSnapshotRecord,
@@ -39,6 +40,7 @@ interface ProjectGroup {
   path: string
   entries: SidebarEntry[]
   updatedAt: number
+  archived?: boolean
   unassigned?: boolean
 }
 
@@ -51,6 +53,12 @@ interface MenuState {
   x: number
   y: number
   entry: SidebarEntry
+}
+
+interface ProjectMenuState {
+  x: number
+  y: number
+  project: Project
 }
 
 function entryTitle(entry: SidebarEntry): string {
@@ -124,6 +132,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
   const deleteTaskSnapshot = useStore((s) => s.deleteTaskSnapshot)
   const setShowTaskRecovery = useStore((s) => s.setShowTaskRecovery)
   const closeSession = useStore((s) => s.closeSession)
+  const archiveProject = useStore((s) => s.archiveProject)
+  const deleteProject = useStore((s) => s.deleteProject)
   const setShowNewSession = useStore((s) => s.setShowNewSession)
   const setShowSettings = useStore((s) => s.setShowSettings)
   const setView = useStore((s) => s.setView)
@@ -133,8 +143,10 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
   const [editing, setEditing] = useState<EditingTarget | null>(null)
   const [draftTitle, setDraftTitle] = useState('')
   const [menu, setMenu] = useState<MenuState | null>(null)
+  const [projectMenu, setProjectMenu] = useState<ProjectMenuState | null>(null)
   const [collapsedProjects, setCollapsedProjects] = useState<Record<string, boolean>>({})
   const [archiveOpen, setArchiveOpen] = useState(false)
+  const [archivedProjectsOpen, setArchivedProjectsOpen] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(layout.sidebarWidth)
 
   useEffect(() => {
@@ -259,7 +271,8 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
         label: project.name,
         path: project.path,
         entries: [],
-        updatedAt: project.lastUsedAt
+        updatedAt: project.lastUsedAt,
+        archived: project.archived === true
       }
       groups.set(project.id, group)
       groupsByPath.set(project.path, group)
@@ -294,14 +307,16 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     }
 
     const q = query.trim().toLowerCase()
-    const projectGroups = [...groups.values()]
+    const matchingGroups = [...groups.values()]
       .filter((group) => !q || group.entries.length > 0 || normalized(`${group.label}\n${group.path}`).includes(q))
       .sort((a, b) => b.updatedAt - a.updatedAt)
+    const projectGroups = matchingGroups.filter((group) => !group.archived)
+    const archivedProjectGroups = matchingGroups.filter((group) => group.archived)
     const showUnassigned = !q || unassigned.entries.length > 0 || normalized(unassigned.label).includes(q)
-    return { projectGroups, unassigned, showUnassigned }
+    return { projectGroups, archivedProjectGroups, unassigned, showUnassigned }
   }, [projectActiveEntries, projects, query, recentHistory, t])
 
-  const { projectGroups, unassigned, showUnassigned } = groupedEntries
+  const { projectGroups, archivedProjectGroups, unassigned, showUnassigned } = groupedEntries
 
   const startRename = (entry: SidebarEntry): void => {
     setEditing({ kind: entry.kind, id: entry.id })
@@ -328,7 +343,18 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     e.preventDefault()
     e.stopPropagation()
     const rect = e.currentTarget.getBoundingClientRect()
+    setProjectMenu(null)
     setMenu({ x: rect.right - 4, y: rect.bottom + 4, entry })
+  }
+
+  const showProjectButtonMenu = (e: React.MouseEvent<HTMLButtonElement>, projectId: string): void => {
+    e.preventDefault()
+    e.stopPropagation()
+    const project = projects.find((item) => item.id === projectId)
+    if (!project) return
+    const rect = e.currentTarget.getBoundingClientRect()
+    setMenu(null)
+    setProjectMenu({ x: rect.right - 4, y: rect.bottom + 4, project })
   }
 
   const copyPath = (path: string): void => {
@@ -377,6 +403,24 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     })
     return items
   }
+
+  const projectMenuItemsFor = (project: Project): SessionMenuItem[] => [
+    {
+      key: 'archive-project',
+      label: project.archived ? t('unarchiveProject') : t('archiveProject'),
+      onClick: () => void archiveProject(project.id, !project.archived)
+    },
+    { key: 'copy-project-path', label: t('copyPath'), onClick: () => copyPath(project.path) },
+    {
+      key: 'delete-project',
+      label: t('deleteProject'),
+      danger: true,
+      onClick: () => {
+        if (!window.confirm(t('deleteProjectConfirm', { name: project.name }))) return
+        void deleteProject(project.id)
+      }
+    }
+  ]
 
   const renderTitle = (entry: SidebarEntry): React.ReactNode => {
     const isolated = entry.kind === 'active' ? entry.meta.isolated : entry.history.isolated
@@ -503,6 +547,55 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
   const renderSidebarEntry = (entry: SidebarEntry): React.ReactNode =>
     entry.kind === 'active' ? renderActiveEntry(entry) : renderHistoryEntry(entry.history)
 
+  const renderProjectGroup = (group: ProjectGroup, allowNewSession: boolean): React.ReactNode => {
+    const collapsed = collapsedProjects[group.key] === true
+    return (
+      <div key={group.key} className="sidebar-project-group" data-project-id={group.projectId}>
+        <div className="sidebar-group-row">
+          <button
+            className="sidebar-group-head"
+            title={group.path}
+            onClick={() => setCollapsedProjects((state) => ({ ...state, [group.key]: !collapsed }))}
+          >
+            <span className="sidebar-group-caret">{collapsed ? '▸' : '▾'}</span>
+            <span className="sidebar-group-title">{group.label}</span>
+            <span className="sidebar-group-count">{group.entries.length}</span>
+          </button>
+          {allowNewSession && (
+            <button
+              type="button"
+              className="sidebar-group-new"
+              aria-label={`${t('newSessionHere')}: ${group.label}`}
+              title={t('newSessionHere')}
+              onClick={() => {
+                closeMobile()
+                setShowNewSession(true, group.projectId)
+              }}
+            >
+              +
+            </button>
+          )}
+          {group.projectId && (
+            <button
+              type="button"
+              className="sidebar-group-more"
+              aria-label={t('projectActions', { name: group.label })}
+              title={t('moreActions')}
+              aria-haspopup="menu"
+              onClick={(event) => showProjectButtonMenu(event, group.projectId!)}
+            >
+              ⋯
+            </button>
+          )}
+        </div>
+        {!collapsed && group.entries.map(renderSidebarEntry)}
+        {!collapsed && group.entries.length === 0 && (
+          <div className="sidebar-empty sidebar-group-empty">{t('noSessions')}</div>
+        )}
+      </div>
+    )
+  }
+
   const renderSearchHit = (result: TranscriptSearchResult): React.ReactNode => {
     const first = result.hits[0]
     return (
@@ -577,6 +670,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
     pinnedEntries.length +
     visibleTaskSnapshots.length +
     projectGroups.reduce((count, group) => count + group.entries.length, 0) +
+    archivedProjectGroups.reduce((count, group) => count + group.entries.length, 0) +
     unassigned.entries.length +
     archivedHistory.length
   const archiveExpanded = archiveOpen || query.trim().length > 0
@@ -668,39 +762,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
         {(projectGroups.length > 0 || showUnassigned) && (
           <section className="sidebar-section sidebar-projects-section">
             <div className="sidebar-section-title">{t('projects')}</div>
-            {projectGroups.map((group) => {
-              const collapsed = collapsedProjects[group.key] === true
-              return (
-                <div key={group.key} className="sidebar-project-group" data-project-id={group.projectId}>
-                  <div className="sidebar-group-row">
-                    <button
-                      className="sidebar-group-head"
-                      title={group.path}
-                      onClick={() =>
-                        setCollapsedProjects((state) => ({ ...state, [group.key]: !collapsed }))
-                      }
-                    >
-                      <span className="sidebar-group-caret">{collapsed ? '▸' : '▾'}</span>
-                      <span className="sidebar-group-title">{group.label}</span>
-                      <span className="sidebar-group-count">{group.entries.length}</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="sidebar-group-new"
-                      aria-label={`${t('newSessionHere')}: ${group.label}`}
-                      title={t('newSessionHere')}
-                      onClick={() => {
-                        closeMobile()
-                        setShowNewSession(true, group.projectId)
-                      }}
-                    >
-                      +
-                    </button>
-                  </div>
-                  {!collapsed && group.entries.map(renderSidebarEntry)}
-                </div>
-              )
-            })}
+            {projectGroups.map((group) => renderProjectGroup(group, true))}
             {showUnassigned && (
               <div className="sidebar-project-group sidebar-unassigned-group" data-project-id="unassigned">
                 {(() => {
@@ -729,6 +791,21 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           </section>
         )}
 
+        {archivedProjectGroups.length > 0 && (
+          <section className="sidebar-section sidebar-archived-projects-section">
+            <button
+              className="sidebar-section-toggle"
+              onClick={() => setArchivedProjectsOpen((value) => !value)}
+            >
+              <span>{archivedProjectsOpen || query.trim() ? '▾' : '▸'}</span>
+              <span>{t('archivedProjects')}</span>
+              <span className="sidebar-group-count">{archivedProjectGroups.length}</span>
+            </button>
+            {(archivedProjectsOpen || query.trim()) &&
+              archivedProjectGroups.map((group) => renderProjectGroup(group, false))}
+          </section>
+        )}
+
         {archivedHistory.length > 0 && (
           <section className="sidebar-section">
             <button className="sidebar-section-toggle" onClick={() => setArchiveOpen((value) => !value)}>
@@ -750,7 +827,7 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           </section>
         )}
 
-        {query.trim() && totalVisible === 0 && projectGroups.length === 0 && !showUnassigned && (
+        {query.trim() && totalVisible === 0 && projectGroups.length === 0 && archivedProjectGroups.length === 0 && !showUnassigned && (
           <div className="sidebar-empty">{t('noMatchingSessions')}</div>
         )}
       </div>
@@ -782,6 +859,14 @@ export default function Sidebar({ mobileOpen = false, onMobileClose }: SidebarPr
           y={menu.y}
           items={menuItemsFor(menu.entry)}
           onClose={() => setMenu(null)}
+        />
+      )}
+      {projectMenu && (
+        <SessionContextMenu
+          x={projectMenu.x}
+          y={projectMenu.y}
+          items={projectMenuItemsFor(projectMenu.project)}
+          onClose={() => setProjectMenu(null)}
         />
       )}
     </aside>

--- a/src/renderer/src/components/StartSuggestionsPanel.tsx
+++ b/src/renderer/src/components/StartSuggestionsPanel.tsx
@@ -25,7 +25,7 @@ export interface StartSuggestionsPanelProps {
 
 const DEFAULT_LABELS: StartSuggestionsPanelLabels = {
   title: '开工建议',
-  subtitle: '基于当前项目状态，先挑一个能直接推进的动作。',
+  subtitle: '基于当前工作目录状态，先挑一个能直接推进的动作。',
   reason: '理由',
   promptPreview: '将发送',
   sendToAgent: '发送给 Agent',

--- a/src/renderer/src/components/WelcomeView.tsx
+++ b/src/renderer/src/components/WelcomeView.tsx
@@ -36,7 +36,8 @@ export default function WelcomeView(): React.JSX.Element {
   const requestedProjectId = useStore((s) => s.newSessionProjectId)
   const startSessionWithPrompt = useStore((s) => s.startSessionWithPrompt)
 
-  const initialProject = projects.find((project) => project.id === requestedProjectId) ?? projects[0]
+  const availableProjects = useMemo(() => projects.filter((project) => !project.archived), [projects])
+  const initialProject = availableProjects.find((project) => project.id === requestedProjectId) ?? availableProjects[0]
   const initialProvider = providers.find((provider) => provider.id === settings.defaultProviderId && provider.hasToken)
   const [text, setText] = useState('')
   const [projectChoice, setProjectChoice] = useState(initialProject?.id ?? NEW_PROJECT)
@@ -59,18 +60,25 @@ export default function WelcomeView(): React.JSX.Element {
   const taRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
-    if (projectChoice !== NEW_PROJECT || cwd || projects.length === 0) return
-    setProjectChoice(projects[0].id)
-    setCwd(projects[0].path)
-  }, [cwd, projectChoice, projects])
+    if (projectChoice !== NEW_PROJECT || cwd || availableProjects.length === 0) return
+    setProjectChoice(availableProjects[0].id)
+    setCwd(availableProjects[0].path)
+  }, [availableProjects, cwd, projectChoice])
 
   useEffect(() => {
     if (!requestedProjectId) return
-    const requested = projects.find((project) => project.id === requestedProjectId)
+    const requested = availableProjects.find((project) => project.id === requestedProjectId)
     if (!requested) return
     setProjectChoice(requested.id)
     setCwd(requested.path)
-  }, [projects, requestedProjectId])
+  }, [availableProjects, requestedProjectId])
+
+  useEffect(() => {
+    if (projectChoice === NEW_PROJECT || projectChoice === UNASSIGNED) return
+    if (availableProjects.some((project) => project.id === projectChoice)) return
+    setProjectChoice(UNASSIGNED)
+    setCwd('')
+  }, [availableProjects, projectChoice])
 
   useEffect(() => {
     if (providerId) return
@@ -172,7 +180,7 @@ export default function WelcomeView(): React.JSX.Element {
       await startSessionWithPrompt(
         {
           cwd: cwd.trim(),
-          projectId: projects.some((project) => project.id === projectChoice) ? projectChoice : undefined,
+          projectId: availableProjects.some((project) => project.id === projectChoice) ? projectChoice : undefined,
           unassigned: projectChoice === UNASSIGNED,
           driveMode,
           model: routingMode === 'fixed' ? model : AUTO_MODEL,
@@ -229,7 +237,7 @@ export default function WelcomeView(): React.JSX.Element {
               value={projectChoice}
               onChange={(e) => onProjectChange(e.target.value)}
             >
-              {projects.map((project) => (
+              {availableProjects.map((project) => (
                 <option key={project.id} value={project.id}>
                   {project.name}
                 </option>

--- a/src/renderer/src/i18n.ts
+++ b/src/renderer/src/i18n.ts
@@ -15,7 +15,16 @@ const DICT: Dict = {
   listView: { zh: '列表视图', en: 'List View' },
   ongoing: { zh: '进行中', en: 'Active' },
   projects: { zh: '项目', en: 'Projects' },
+  archivedProjects: { zh: '已归档项目', en: 'Archived projects' },
   newSessionHere: { zh: '在此项目新建会话', en: 'New session here' },
+  projectActions: { zh: '项目操作: {name}', en: 'Project actions: {name}' },
+  archiveProject: { zh: '归档项目', en: 'Archive project' },
+  unarchiveProject: { zh: '恢复项目', en: 'Restore project' },
+  deleteProject: { zh: '删除项目', en: 'Delete project' },
+  deleteProjectConfirm: {
+    zh: '删除项目「{name}」? 项目目录和会话不会被删除，相关会话将移入「未关联项目」。',
+    en: 'Delete project "{name}"? Its directory and sessions will be kept; related sessions will move to "No project".'
+  },
   unassignedSessions: { zh: '未关联项目', en: 'No project' },
   recent: { zh: '最近会话', en: 'Recent' },
   pinned: { zh: '置顶', en: 'Pinned' },
@@ -476,6 +485,9 @@ const DICT: Dict = {
     en: 'Stops the next Routine send after the limit is reached; 0 means unlimited.'
   },
   memoryShort: { zh: '记忆', en: 'Memory' },
+  startSuggestionsShort: { zh: '开工建议', en: 'Start suggestions' },
+  startSuggestionsLoading: { zh: '正在分析当前工作目录…', en: 'Analyzing the current working directory…' },
+  startSuggestionsEmpty: { zh: '当前工作目录没有可用的开工建议', en: 'No start suggestions for this working directory' },
   filePanelTitle: { zh: '文件编辑器', en: 'File editor' },
   filesTruncated: { zh: '文件过多,已截断', en: 'File list truncated' },
   fileSearchPlaceholder: { zh: '搜索文件…', en: 'Search files…' },

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -895,6 +895,7 @@ interface AppStore {
   updateProvider(id: string, patch: Partial<ProviderInput>): Promise<void>
   deleteProvider(id: string): Promise<void>
   refreshProjects(): Promise<void>
+  archiveProject(id: string, archived: boolean): Promise<void>
   deleteProject(id: string): Promise<void>
   setShowNewSession(v: boolean, projectId?: string): void
   setShowSettings(v: boolean): void
@@ -1667,19 +1668,37 @@ export const useStore = create<AppStore>((set, get) => {
     closeNativeBrowserView(id)
     await window.agentDesk.closeSession(id)
     pendingEvents.delete(id)
+    const [historyResult, taskSnapshotsResult] = await Promise.allSettled([
+      window.agentDesk.listHistory(),
+      window.agentDesk.listTaskSnapshots()
+    ])
     set((s) => {
       const sessions = { ...s.sessions }
       delete sessions[id]
       const order = s.order.filter((x) => x !== id)
+      const requestedActiveId = s.activeId === id ? null : s.activeId
+      const activeId = requestedActiveId && sessions[requestedActiveId]
+        ? requestedActiveId
+        : (order[order.length - 1] ?? null)
       return {
         sessions,
         order,
-        activeId: s.activeId === id ? (order[order.length - 1] ?? null) : s.activeId
+        activeId,
+        history: historyResult.status === 'fulfilled' ? historyResult.value : s.history,
+        taskSnapshots: taskSnapshotsResult.status === 'fulfilled' ? taskSnapshotsResult.value : s.taskSnapshots,
+        taskSnapshotsLoading: false,
+        taskSnapshotsError:
+          taskSnapshotsResult.status === 'rejected'
+            ? taskSnapshotsResult.reason instanceof Error
+              ? taskSnapshotsResult.reason.message
+              : String(taskSnapshotsResult.reason)
+            : undefined,
+        showNewSession: activeId === null ? true : s.showNewSession,
+        newSessionProjectId: activeId === null ? null : s.newSessionProjectId,
+        showTaskRecovery: false,
+        view: activeId === null ? 'list' : s.view
       }
     })
-    const history = await window.agentDesk.listHistory()
-    set({ history })
-    void get().refreshTaskSnapshots()
   },
 
   async respondPermission(sessionId, requestId, allow, message) {
@@ -3550,12 +3569,14 @@ export const useStore = create<AppStore>((set, get) => {
     set((s) => ({
       workbench: {
         ...s.workbench,
+        startSuggestions: [],
         startSuggestionsLoading: true,
         startSuggestionsError: undefined
       }
     }))
     try {
       const suggestions = await window.agentDesk.getStartSuggestions(id)
+      if (get().activeId !== id) return
       set((s) => ({
         workbench: {
           ...s.workbench,
@@ -3565,6 +3586,7 @@ export const useStore = create<AppStore>((set, get) => {
         }
       }))
     } catch (err) {
+      if (get().activeId !== id) return
       set((s) => ({
         workbench: {
           ...s.workbench,
@@ -3774,13 +3796,32 @@ export const useStore = create<AppStore>((set, get) => {
     set({ projects })
   },
 
+  async archiveProject(id, archived) {
+    await window.agentDesk.updateProject(id, { archived })
+    const projects = await window.agentDesk.listProjects()
+    set((s) => ({
+      projects,
+      newSessionProjectId: s.newSessionProjectId === id ? null : s.newSessionProjectId
+    }))
+  },
+
   async deleteProject(id) {
     await window.agentDesk.deleteProject(id)
-    await get().refreshProjects()
+    const projects = await window.agentDesk.listProjects()
+    set((s) => ({
+      projects,
+      newSessionProjectId: s.newSessionProjectId === id ? null : s.newSessionProjectId
+    }))
   },
 
   setShowNewSession(v, projectId) {
-    set({ showNewSession: v, newSessionProjectId: v ? projectId ?? null : null })
+    set((s) => ({
+      showNewSession: v,
+      newSessionProjectId: v ? projectId ?? null : null,
+      showSettings: v ? false : s.showSettings,
+      showTaskRecovery: v ? false : s.showTaskRecovery,
+      view: v ? 'list' : s.view
+    }))
   },
 
   setShowSettings(v) {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -606,7 +606,8 @@ textarea {
   width: auto;
 }
 
-.sidebar-group-new {
+.sidebar-group-new,
+.sidebar-group-more {
   width: 28px;
   height: 28px;
   flex: 0 0 28px;
@@ -621,9 +622,14 @@ textarea {
   line-height: 1;
 }
 
-.sidebar-group-new:hover {
+.sidebar-group-new:hover,
+.sidebar-group-more:hover {
   background: var(--bg-card);
   color: var(--text);
+}
+
+.sidebar-group-more {
+  font-size: 16px;
 }
 
 .sidebar-unassigned-group {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -956,6 +956,13 @@ export interface Project {
   name: string
   path: string
   lastUsedAt: number
+  /** 归档项目保留会话关联，但不参与新建会话选择。 */
+  archived?: boolean
+}
+
+export interface ProjectUpdate {
+  name?: string
+  archived?: boolean
 }
 
 export type ProjectContextFileName = 'caogen.md' | '.caogen.md' | 'README.md'
@@ -2428,7 +2435,7 @@ export interface AgentDeskApi {
   scanMigration(cwd: string): Promise<MigrationScan>
   importMigrationAssets(cwd: string, paths: string[]): Promise<string>
   listProjects(): Promise<Project[]>
-  updateProject(id: string, patch: { name?: string }): Promise<Project | null>
+  updateProject(id: string, patch: ProjectUpdate): Promise<Project | null>
   deleteProject(id: string): Promise<void>
   readProjectContext(projectPath: string): Promise<ProjectContextReadResult>
   writeProjectContext(projectPath: string, content: string): Promise<ProjectContextReadResult>


### PR DESCRIPTION
## What changed

- keep the new-session composer usable after deleting the last session and make the 3D office new-session action work
- allow sessions without a project while preserving a unified "No project" section
- add project archive, restore, and delete actions without deleting project directories or sessions
- make start suggestions opt-in from the chat menu and scope their signals to the current working directory and provider
- add the official website, https://www.caogen.dev, to the README header
- extend page and Electron end-to-end coverage for these workflows

## Why

Session creation and project organization diverged from the intended Codex-style workflow. Empty-session recovery, the office entry point, and project lifecycle actions also had gaps. Start suggestions were generated automatically and could include unrelated global history, routines, or provider failures.

## User impact

Users can start unassigned sessions, recover cleanly after deleting the last session, manage project lifecycle from the sidebar, and request scoped start suggestions only when needed.

## Validation

- `npm run typecheck`
- `npm run build`
- `node scripts/integration-test.cjs` (`42/42`)
- `npm run test:page` (`22/22`)
- `node scripts/start-suggestions-smoke.mjs`
- `node scripts/start-suggestions-e2e.mjs` (`6/6`)
- `npm run test:coding-standards`
- `npm run secret:scan`
- `git diff --check`
