### PR TITLE
fix: harden release asset text audit

### DIFF
--- a/scripts/github-release-audit.mjs
+++ b/scripts/github-release-audit.mjs
@@ -105,6 +105,7 @@ async function inspectAsset(tagName, tagVersion, asset) {
   const size = numberField(asset, 'size') || 0
   const state = stringField(asset, 'state') || 'unknown'
   const contentType = stringField(asset, 'content_type') || ''
+  const apiDownloadUrl = stringField(asset, 'url') || ''
   const browserDownloadUrl = stringField(asset, 'browser_download_url') || ''
   const categories = {
     allowedName: allowedReleaseAssetName(name),
@@ -125,7 +126,8 @@ async function inspectAsset(tagName, tagVersion, asset) {
   }
 
   if (readTextAssets && shouldReadSmallTextAsset(name, size)) {
-    const text = asset.textContent ?? (browserDownloadUrl ? await readTextAsset(tagName, name, browserDownloadUrl) : undefined)
+    const downloadUrls = [apiDownloadUrl, browserDownloadUrl].filter(Boolean)
+    const text = asset.textContent ?? (downloadUrls.length > 0 ? await readTextAsset(tagName, name, downloadUrls) : undefined)
     if (typeof text === 'string') {
       scanText(text, `${tagName}/${name}`)
       if (/^latest.*\.ya?ml$/i.test(name) && tagVersion && !text.includes(`version: ${tagVersion}`)) {
@@ -205,15 +207,19 @@ function readExpectedDistAssets() {
     .sort()
 }
 
-async function readTextAsset(tagName, assetName, url) {
-  try {
-    return await httpGetText(url, { Accept: 'application/octet-stream' })
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (required) failures.push(`${tagName}/${assetName}: unable to read text release asset: ${message}`)
-    else warnings.push(`${tagName}/${assetName}: unable to read text release asset: ${message}`)
-    return undefined
+async function readTextAsset(tagName, assetName, urls) {
+  let lastError
+  for (const url of urls) {
+    try {
+      return await httpGetText(url, { Accept: 'application/octet-stream' })
+    } catch (error) {
+      lastError = error
+    }
   }
+  const message = lastError instanceof Error ? lastError.message : String(lastError)
+  if (required) failures.push(`${tagName}/${assetName}: unable to read text release asset: ${message}`)
+  else warnings.push(`${tagName}/${assetName}: unable to read text release asset: ${message}`)
+  return undefined
 }
 
 function scanText(text, label) {


### PR DESCRIPTION
## What changed

- Read small GitHub Release text assets through the official asset API URL first.
- Fall back to the public browser download URL when the API asset URL fails.
- Report a read failure only after both transport paths fail.

## Why

The v0.1.6 asset inventory and GitHub SHA256 digests were correct, but the public browser download path repeatedly timed out for the 484-byte latest-mac.yml file. The authenticated and public GitHub asset API path returned the same file immediately.

## Validation

- node syntax check passed
- worktree secret scan passed
- v0.1.6 required read-text audit passed with exactly five assets, matching SHA256 digests, and valid version 0.1.6 update metadata
