### PR TITLE
[codex] add unsigned Windows installer workflow

### DIFF
--- a/.github/workflows/windows-unsigned-build.yml
+++ b/.github/workflows/windows-unsigned-build.yml
@@ -1,0 +1,74 @@
+name: CaoGen Windows unsigned build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/windows-unsigned-build.yml
+      - package.json
+      - package-lock.json
+      - scripts/packaged-app-smoke.mjs
+      - scripts/prepare-native-build.cjs
+      - scripts/windows-unsigned-workflow-contract-smoke.mjs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: caogen-windows-unsigned-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  windows-x64:
+    name: Windows x64 unsigned installer
+    runs-on: windows-2025
+    steps:
+      - name: Check out the selected commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install exact dependencies
+        run: npm ci
+      - name: Verify source and workflow contracts
+        run: |
+          npm run test:release-workflow-contract
+          npm run test:windows-release-config
+          npm run typecheck
+      - name: Build application
+        run: npm run build
+      - name: Prepare native modules
+        run: npm run prepare:native-build
+      - name: Build unsigned Windows installer
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: npx electron-builder --win --x64 --publish never
+      - name: Verify unsigned installer in a custom directory
+        run: npm run test:packaged-app:win:x64:unsigned
+      - name: Read package version
+        id: package
+        shell: pwsh
+        run: |
+          $Package = Get-Content -Raw package.json | ConvertFrom-Json
+          "version=$($Package.version)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+      - name: Upload unsigned installer and evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: caogen-windows-x64-unsigned-${{ github.sha }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+          path: |
+            dist/CaoGen Setup ${{ steps.package.outputs.version }}.exe
+            dist/CaoGen Setup ${{ steps.package.outputs.version }}.exe.blockmap
+            dist/latest.yml
+            test-results/packaged-app-smoke/latest-windows-unsigned-x64.json

--- a/package.json
+++ b/package.json
@@ -238,7 +238,8 @@
     "test:release-packaging-audit": "node scripts/release-packaging-audit.mjs",
     "test:release-packaging-audit:required": "node scripts/release-packaging-audit.mjs --required",
     "test:release-packaging-policy": "node scripts/release-packaging-policy-smoke.mjs",
-    "test:release-workflow-contract": "node scripts/release-workflow-contract-smoke.mjs",
+    "test:release-workflow-contract": "node scripts/release-workflow-contract-smoke.mjs && node scripts/windows-unsigned-workflow-contract-smoke.mjs",
+    "test:windows-unsigned-workflow-contract": "node scripts/windows-unsigned-workflow-contract-smoke.mjs",
     "test:macos-x64-release-evidence": "node scripts/macos-x64-release-evidence-smoke.mjs",
     "test:macos-x64-release-evidence:required": "npm run test:macos-x64-release-evidence",
     "test:package-size-policy": "node scripts/package-size-policy-smoke.mjs",
@@ -258,6 +259,7 @@
     "test:packaged-app:mac:x64": "node scripts/packaged-app-smoke.mjs --platform macos --arch x64",
     "test:packaged-app:mac:arm64": "node scripts/packaged-app-smoke.mjs --platform macos --arch arm64",
     "test:packaged-app:win:x64": "node scripts/packaged-app-smoke.mjs --platform windows --arch x64",
+    "test:packaged-app:win:x64:unsigned": "node scripts/packaged-app-smoke.mjs --platform windows --arch x64 --unsigned",
     "test:release-notes-audit": "node scripts/release-notes-audit.mjs",
     "test:release-notes-audit:required": "node scripts/release-notes-audit.mjs --required",
     "test:release-notes-audit:final": "node scripts/release-notes-audit.mjs --required --final",
@@ -417,6 +419,10 @@
       "target": [
         "nsis"
       ]
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
     },
     "linux": {
       "icon": "resources/icon.png",

--- a/scripts/packaged-app-smoke.mjs
+++ b/scripts/packaged-app-smoke.mjs
@@ -404,7 +404,7 @@ $Signature = Get-AuthenticodeSignature -LiteralPath ${powerShellLiteral(filePath
   Timestamped = $null -ne $Signature.TimeStamperCertificate
 } | ConvertTo-Json -Compress
 `
-  const result = spawnSync('powershell.exe', [
+  const result = spawnSync(powerShellExecutable(), [
     '-NoLogo',
     '-NoProfile',
     '-NonInteractive',
@@ -435,6 +435,14 @@ $Signature = Get-AuthenticodeSignature -LiteralPath ${powerShellLiteral(filePath
 
 function powerShellLiteral(value) {
   return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function powerShellExecutable() {
+  const probe = spawnSync('where.exe', ['pwsh.exe'], {
+    stdio: 'ignore',
+    windowsHide: true
+  })
+  return probe.status === 0 ? 'pwsh.exe' : 'powershell.exe'
 }
 
 function platformLabel(platform) {

--- a/scripts/packaged-app-smoke.mjs
+++ b/scripts/packaged-app-smoke.mjs
@@ -16,6 +16,7 @@ const reportDir = path.join(reportRoot, runId)
 const requestedPlatform = argValue('--platform') || process.platform
 const targetPlatform = requestedPlatform === 'macos' ? 'darwin' : requestedPlatform === 'windows' ? 'win32' : requestedPlatform
 const targetArch = argValue('--arch') || process.arch
+const unsignedBuild = process.argv.includes('--unsigned')
 const sourceArtifact = releaseArtifactPath(targetPlatform, targetArch, packageJson.version)
 const releaseAudit = readReleaseAudit(targetPlatform, targetArch)
 const userDataDir = mkdtempSync(path.join(tmpdir(), 'caogen-packaged-app-smoke-'))
@@ -24,6 +25,7 @@ const git = readGitState()
 let appRoot
 let appExecutable
 let buildProvenance = null
+let signing = null
 let mountedDmg
 let child
 let stderr = ''
@@ -45,12 +47,19 @@ try {
     throw new Error(`packaged app smoke for ${targetPlatform} must run on ${targetPlatform}, got ${process.platform}`)
   }
   if (targetArch !== 'x64' && targetArch !== 'arm64') throw new Error(`unsupported packaged app architecture: ${targetArch}`)
+  if (unsignedBuild && targetPlatform !== 'win32') throw new Error('unsigned packaged app smoke is Windows-only')
   if (process.arch !== targetArch) {
     throw new Error(`native packaged app smoke for ${targetArch} must run on ${targetArch}, got ${process.arch}`)
   }
-  assertReleaseAuditBinding(releaseAudit)
+  if (!unsignedBuild) assertReleaseAuditBinding(releaseAudit)
   if (!existsSync(sourceArtifact)) {
     throw new Error(`release installer is missing: ${path.relative(repoRoot, sourceArtifact)}`)
+  }
+  if (unsignedBuild) {
+    signing = { installer: inspectAuthenticode(sourceArtifact), app: null }
+    if (signing.installer.status !== 'NotSigned') {
+      throw new Error(`unsigned installer has unexpected Authenticode status: ${signing.installer.status}`)
+    }
   }
   const installed = installCandidate()
   appRoot = installed.appRoot
@@ -58,15 +67,22 @@ try {
   appExecutable = packagedExecutable(appRoot, targetPlatform)
   if (!existsSync(appExecutable)) throw new Error('installed application executable is missing')
   installation.status = 'passed'
-  const inspectedProvenance = readPackagedReleaseProvenanceFromAsar(packagedAsarPath(appRoot, targetPlatform))
-  buildProvenance = inspectedProvenance.value
-  if (inspectedProvenance.error) throw new Error(`packaged release provenance is unreadable: ${inspectedProvenance.error}`)
-  const provenanceFailures = Object.entries(releaseProvenanceChecks(buildProvenance, {
-    gitCommit: git.commit,
-    packageVersion: packageJson.version
-  })).filter(([, passed]) => !passed)
-  if (provenanceFailures.length > 0) {
-    throw new Error(`packaged release provenance failed: ${provenanceFailures.map(([name]) => name).join(', ')}`)
+  if (unsignedBuild) {
+    signing.app = inspectAuthenticode(appExecutable)
+    if (signing.app.status !== 'NotSigned') {
+      throw new Error(`unsigned application has unexpected Authenticode status: ${signing.app.status}`)
+    }
+  } else {
+    const inspectedProvenance = readPackagedReleaseProvenanceFromAsar(packagedAsarPath(appRoot, targetPlatform))
+    buildProvenance = inspectedProvenance.value
+    if (inspectedProvenance.error) throw new Error(`packaged release provenance is unreadable: ${inspectedProvenance.error}`)
+    const provenanceFailures = Object.entries(releaseProvenanceChecks(buildProvenance, {
+      gitCommit: git.commit,
+      packageVersion: packageJson.version
+    })).filter(([, passed]) => !passed)
+    if (provenanceFailures.length > 0) {
+      throw new Error(`packaged release provenance failed: ${provenanceFailures.map(([name]) => name).join(', ')}`)
+    }
   }
   const port = await availablePort()
   child = spawn(appExecutable, [`--remote-debugging-port=${port}`, '--enable-logging=stderr'], {
@@ -83,7 +99,7 @@ try {
   })
 
   target = await waitForRenderer(child, port, 30_000)
-  if (/Uncaught Exception|Cannot find module/i.test(stderr)) {
+  if (/Uncaught Exception|Cannot find module|NODE_MODULE_VERSION/i.test(stderr)) {
     throw new Error('packaged app emitted a main-process module loading error')
   }
 } catch (error) {
@@ -114,6 +130,7 @@ if (!failure && cleanupFailure) failure = `temporary user-data cleanup failed: $
 
 const report = {
   status: failure ? 'failed' : 'passed',
+  mode: unsignedBuild ? 'unsigned' : 'signed-release',
   runId,
   reportDir,
   packageVersion: packageJson.version,
@@ -121,12 +138,13 @@ const report = {
   targetArch,
   appExecutable: appExecutable ? 'isolated-install/CaoGen' : null,
   git,
-  artifactSetSha256: releaseAudit.data?.artifactSetSha256 || null,
+  artifactSetSha256: unsignedBuild ? null : releaseAudit.data?.artifactSetSha256 || null,
   releaseAudit: {
     path: releaseAudit.relativePath,
-    status: releaseAudit.data?.status || (releaseAudit.error ? 'invalid_json' : 'missing')
+    status: unsignedBuild ? 'not-required' : releaseAudit.data?.status || (releaseAudit.error ? 'invalid_json' : 'missing')
   },
   buildProvenance,
+  signing,
   installation,
   target,
   failure,
@@ -138,7 +156,10 @@ const report = {
 mkdirSync(reportDir, { recursive: true })
 writeFileSync(path.join(reportDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8')
 writeFileSync(path.join(reportRoot, 'latest.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8')
-writeFileSync(path.join(reportRoot, `latest-${platformLabel(targetPlatform)}-${targetArch}.json`), `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+const reportName = unsignedBuild
+  ? `latest-${platformLabel(targetPlatform)}-unsigned-${targetArch}.json`
+  : `latest-${platformLabel(targetPlatform)}-${targetArch}.json`
+writeFileSync(path.join(reportRoot, reportName), `${JSON.stringify(report, null, 2)}\n`, 'utf8')
 
 console.log(JSON.stringify(report, null, 2))
 if (failure) process.exitCode = 1
@@ -371,6 +392,49 @@ function assertReleaseAuditBinding(audit) {
   if (audit.data.git?.worktreeClean !== true || !git.worktreeClean) failures.push('cleanGit')
   if (!/^[0-9a-f]{64}$/i.test(audit.data.artifactSetSha256 || '')) failures.push('artifactSetSha256')
   if (failures.length > 0) throw new Error(`release audit binding failed: ${failures.join(', ')}`)
+}
+
+function inspectAuthenticode(filePath) {
+  const script = `
+$ErrorActionPreference = 'Stop'
+$Signature = Get-AuthenticodeSignature -LiteralPath ${powerShellLiteral(filePath)}
+@{
+  Status = [string]$Signature.Status
+  HasCertificate = $null -ne $Signature.SignerCertificate
+  Timestamped = $null -ne $Signature.TimeStamperCertificate
+} | ConvertTo-Json -Compress
+`
+  const result = spawnSync('powershell.exe', [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-EncodedCommand',
+    Buffer.from(script, 'utf16le').toString('base64')
+  ], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    windowsHide: true,
+    maxBuffer: 1024 * 1024
+  })
+  if (result.status !== 0) {
+    throw new Error(`Authenticode inspection failed: ${commandFailure(result)}`)
+  }
+  try {
+    const data = JSON.parse(String(result.stdout || '').trim())
+    return {
+      status: typeof data.Status === 'string' ? data.Status : 'Unknown',
+      hasCertificate: data.HasCertificate === true,
+      timestamped: data.Timestamped === true
+    }
+  } catch (error) {
+    throw new Error(`Authenticode inspection returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function powerShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`
 }
 
 function platformLabel(platform) {

--- a/scripts/windows-release-audit.mjs
+++ b/scripts/windows-release-audit.mjs
@@ -197,7 +197,7 @@ $Signature = Get-AuthenticodeSignature -LiteralPath ${powerShellLiteral(filePath
   Timestamped = $null -ne $Signature.TimeStamperCertificate
 } | ConvertTo-Json -Compress
 `
-  const result = spawnSync('powershell.exe', [
+  const result = spawnSync(powerShellExecutable(), [
     '-NoLogo',
     '-NoProfile',
     '-NonInteractive',
@@ -318,6 +318,14 @@ function reportPath(value) {
 
 function powerShellLiteral(value) {
   return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function powerShellExecutable() {
+  const probe = spawnSync('where.exe', ['pwsh.exe'], {
+    stdio: 'ignore',
+    windowsHide: true
+  })
+  return probe.status === 0 ? 'pwsh.exe' : 'powershell.exe'
 }
 
 function redact(value) {

--- a/scripts/windows-release-audit.mjs
+++ b/scripts/windows-release-audit.mjs
@@ -88,6 +88,8 @@ function inspectReleaseConfig() {
     loaded: false,
     forceCodeSigning: false,
     nsisTarget: false,
+    assistedInstaller: false,
+    customInstallDirectory: false,
     releaseProvenance: null
   }
   check('config', 'package version is stable semver', /^\d+\.\d+\.\d+$/.test(version))
@@ -103,12 +105,17 @@ function inspectReleaseConfig() {
     const releaseConfig = require(configPath)
     result.loaded = isRecord(releaseConfig)
     const win = isRecord(releaseConfig?.win) ? releaseConfig.win : {}
+    const nsis = isRecord(releaseConfig?.nsis) ? releaseConfig.nsis : {}
     result.forceCodeSigning = win.forceCodeSigning === true
     result.nsisTarget = hasTarget(win.target, 'nsis')
+    result.assistedInstaller = nsis.oneClick === false
+    result.customInstallDirectory = nsis.allowToChangeInstallationDirectory === true
     result.releaseProvenance = releaseConfig.extraMetadata?.caogenReleaseProvenance || null
     check('config', 'electron-builder.release.cjs exports an object', result.loaded)
     check('config', 'Windows release requires code signing', result.forceCodeSigning)
     check('config', 'Windows release includes the NSIS target', result.nsisTarget)
+    check('config', 'Windows release uses the assisted installer', result.assistedInstaller)
+    check('config', 'Windows release allows a custom installation directory', result.customInstallDirectory)
     check('config', 'Windows release provenance schema is supported', result.releaseProvenance?.schemaVersion === 1)
     check('config', 'Windows release provenance commit is resolved', /^[0-9a-f]{40}$/i.test(result.releaseProvenance?.gitCommit || ''))
     check('config', 'Windows release provenance version matches package.json', result.releaseProvenance?.packageVersion === version)

--- a/scripts/windows-unsigned-workflow-contract-smoke.mjs
+++ b/scripts/windows-unsigned-workflow-contract-smoke.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import yaml from 'js-yaml'
+
+const repoRoot = process.cwd()
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'windows-unsigned-build.yml')
+const source = readFileSync(workflowPath, 'utf8')
+const workflow = yaml.load(source)
+const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+const triggers = workflow.on
+
+assert.equal(workflow.name, 'CaoGen Windows unsigned build')
+assert.deepEqual(Object.keys(triggers), ['workflow_dispatch', 'pull_request'])
+assert.deepEqual(triggers.pull_request.branches, ['main'])
+assert.deepEqual(triggers.pull_request.paths, [
+  '.github/workflows/windows-unsigned-build.yml',
+  'package.json',
+  'package-lock.json',
+  'scripts/packaged-app-smoke.mjs',
+  'scripts/prepare-native-build.cjs',
+  'scripts/windows-unsigned-workflow-contract-smoke.mjs'
+], 'pull request builds must be limited to Windows packaging changes')
+assert.deepEqual(workflow.permissions, { contents: 'read' }, 'unsigned Windows workflow must be read-only')
+assert.equal(workflow.concurrency['cancel-in-progress'], false)
+assert.match(workflow.concurrency.group, /github\.event\.pull_request\.number \|\| github\.ref/)
+assert.deepEqual(Object.keys(workflow.jobs), ['windows-x64'])
+
+const job = workflow.jobs['windows-x64']
+assert.equal(job['runs-on'], 'windows-2025')
+const checkout = job.steps.find((step) => step.name === 'Check out the selected commit')
+assert.equal(checkout?.with?.ref, '${{ github.sha }}')
+assert.equal(checkout?.with?.['persist-credentials'], false)
+
+const build = job.steps.find((step) => step.name === 'Build unsigned Windows installer')
+assert.deepEqual(build?.env, { CSC_IDENTITY_AUTO_DISCOVERY: 'false' })
+assert.match(build?.run ?? '', /electron-builder --win --x64 --publish never/)
+
+const verify = job.steps.find((step) => step.name === 'Verify unsigned installer in a custom directory')
+assert.equal(verify?.run, 'npm run test:packaged-app:win:x64:unsigned')
+
+const upload = job.steps.find((step) => step.name === 'Upload unsigned installer and evidence')
+assert(upload, 'unsigned artifact upload step is required')
+assert.equal(upload.with?.['if-no-files-found'], 'error')
+for (const requiredPath of [
+  'dist/CaoGen Setup ${{ steps.package.outputs.version }}.exe',
+  'dist/CaoGen Setup ${{ steps.package.outputs.version }}.exe.blockmap',
+  'dist/latest.yml',
+  'test-results/packaged-app-smoke/latest-windows-unsigned-x64.json'
+]) {
+  assert(String(upload.with?.path || '').includes(requiredPath), `unsigned upload must include ${requiredPath}`)
+}
+
+assert.equal(packageJson.build?.nsis?.oneClick, false, 'unsigned installer must use the assisted installer')
+assert.equal(
+  packageJson.build?.nsis?.allowToChangeInstallationDirectory,
+  true,
+  'unsigned installer must allow a custom installation directory'
+)
+assert.match(
+  packageJson.scripts?.['test:packaged-app:win:x64:unsigned'] ?? '',
+  /packaged-app-smoke\.mjs --platform windows --arch x64 --unsigned/
+)
+assert(!/(^|\n)\s*(push|schedule|release):/m.test(source), 'unsigned builds must not run on pushes, schedules, or releases')
+assert(!/secrets\.|CSC_LINK|CSC_KEY_PASSWORD|electron-builder\.release\.cjs/i.test(source), 'unsigned workflow must not consume signing credentials or release signing config')
+assert(!/gh\s+release|create-release|softprops\/action-gh-release|contents:\s*write/i.test(source), 'unsigned workflow must not publish a release')
+
+for (const action of job.steps.filter((step) => typeof step.uses === 'string').map((step) => step.uses.replace(/\s+#.*$/, ''))) {
+  assert.match(action, /^[^@]+@[0-9a-f]{40}$/i, `action must be pinned to a full commit: ${action}`)
+}
+
+console.log('Windows unsigned workflow contract smoke: passed')


### PR DESCRIPTION
## What changed

- switch the Windows NSIS package to an assisted installer with a selectable installation directory
- add a separate unsigned Windows x64 CI workflow that never consumes signing credentials
- add unsigned install, launch, Authenticode, and cleanup verification
- extend workflow and release configuration contract coverage

## Why

The signed candidate lane fails closed when Windows signing secrets are unavailable. This PR keeps that release boundary intact while providing a clearly labeled unsigned installer for CI testing and internal distribution.

## Validation

- `npm run typecheck`
- `npm run test:release-workflow-contract`
- `npm run test:windows-release-config`
- `npm run test:packaged-app:win:x64:unsigned`
- local NSIS x64 package build with installation into an isolated custom directory
