### PR TITLE
Fix release integrity audit before publication

### DIFF
--- a/.github/workflows/release-integrity-audit.yml
+++ b/.github/workflows/release-integrity-audit.yml
@@ -27,10 +27,41 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - name: Check whether the target release is published
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::package.json contains an invalid release version"
+            exit 1
+          fi
+          tag="v${version}"
+          status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}")"
+          case "$status" in
+            200)
+              echo 'published=true' >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo 'published=false' >> "$GITHUB_OUTPUT"
+              echo "::notice::${tag} is not published; strict release integrity audit is not applicable yet"
+              ;;
+            *)
+              echo "::error::GitHub release lookup failed with HTTP ${status}"
+              exit 1
+              ;;
+          esac
       - name: Audit the published release
+        if: steps.release.outputs.published == 'true'
         run: npm run test:github-release-integrity:required
       - name: Upload the redacted audit report
-        if: always()
+        if: always() && steps.release.outputs.published == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: caogen-release-integrity-${{ github.run_id }}

--- a/scripts/release-integrity-workflow-contract-smoke.mjs
+++ b/scripts/release-integrity-workflow-contract-smoke.mjs
@@ -21,8 +21,17 @@ assert.deepEqual(Object.keys(workflow.jobs), ['audit'])
 
 const job = workflow.jobs.audit
 assert.equal(job['runs-on'], 'ubuntu-24.04')
+const releaseProbe = job.steps.find((step) => step.name === 'Check whether the target release is published')
+assert.equal(releaseProbe?.id, 'release')
+assert.equal(releaseProbe?.env?.GH_TOKEN, '${{ github.token }}')
+assert.match(releaseProbe?.run ?? '', /require\('\.\/package\.json'\)\.version/)
+assert.match(releaseProbe?.run ?? '', /releases\/tags\/\$\{tag\}/)
+assert.match(releaseProbe?.run ?? '', /200\)[\s\S]*published=true/)
+assert.match(releaseProbe?.run ?? '', /404\)[\s\S]*published=false/)
+assert.match(releaseProbe?.run ?? '', /GitHub release lookup failed/)
 const audit = job.steps.find((step) => step.name === 'Audit the published release')
 assert.equal(audit?.run, 'npm run test:github-release-integrity:required')
+assert.equal(audit?.if, "steps.release.outputs.published == 'true'")
 assert.match(
   packageJson.scripts?.['test:github-release-integrity:required'] ?? '',
   /github-release-audit\.mjs --required --read-text-assets --expected-assets-from-notes docs\/RELEASE-NOTES-FINAL\.md/,
@@ -30,7 +39,7 @@ assert.match(
 )
 
 const upload = job.steps.find((step) => step.name === 'Upload the redacted audit report')
-assert.equal(upload?.if, 'always()')
+assert.equal(upload?.if, "always() && steps.release.outputs.published == 'true'")
 assert.equal(upload?.with?.path, 'test-results/github-release-audit/**')
 assert.equal(upload?.with?.['if-no-files-found'], 'error')
 assert(!/gh\s+release|create-release|softprops\/action-gh-release|contents:\s*write/i.test(source), 'integrity audit must not mutate releases')


### PR DESCRIPTION
## Summary
- treat a missing target GitHub Release as not-yet-applicable instead of a failed integrity audit
- keep API failures and every post-publication integrity mismatch blocking
- extend the workflow contract smoke for the publication probe and conditional audit

## Verification
- node scripts/release-integrity-workflow-contract-smoke.mjs
- node scripts/github-release-audit-smoke.mjs
- npm run test:release-workflow-contract